### PR TITLE
#4 Use #include_with_pragmas to include "shared.cginc"

### DIFF
--- a/Assets/Windinator/Core/Runtime/UIExtension/Resources/Windinator.SDF/CanvasProceduralRenderer.shader
+++ b/Assets/Windinator/Core/Runtime/UIExtension/Resources/Windinator.SDF/CanvasProceduralRenderer.shader
@@ -46,7 +46,7 @@ Shader "UI/Windinator/CanvasProceduralRenderer"
         Pass
         {
             CGPROGRAM
-            #include "shared.cginc"
+            #include_with_pragmas "shared.cginc"
 
             float GETSDF(in float2 p)
             {

--- a/Assets/Windinator/Core/Runtime/UIExtension/Resources/Windinator.SDF/LineRenderer.shader
+++ b/Assets/Windinator/Core/Runtime/UIExtension/Resources/Windinator.SDF/LineRenderer.shader
@@ -46,7 +46,7 @@ Shader "UI/Windinator/LineRenderer"
         Pass
         {
             CGPROGRAM
-            #include "shared.cginc"
+            #include_with_pragmas "shared.cginc"
             
             uniform float2 _Points[2048];
 

--- a/Assets/Windinator/Core/Runtime/UIExtension/Resources/Windinator.SDF/Operations/AddOp.shader
+++ b/Assets/Windinator/Core/Runtime/UIExtension/Resources/Windinator.SDF/Operations/AddOp.shader
@@ -46,7 +46,7 @@ Shader "UI/Windinator/AddOp"
         Pass
         {
             CGPROGRAM
-            #include "../shared.cginc"
+            #include_with_pragmas "../shared.cginc"
 
             sampler2D _TextureA;
 

--- a/Assets/Windinator/Core/Runtime/UIExtension/Resources/Windinator.SDF/Operations/BlendOp.shader
+++ b/Assets/Windinator/Core/Runtime/UIExtension/Resources/Windinator.SDF/Operations/BlendOp.shader
@@ -46,7 +46,7 @@ Shader "UI/Windinator/BlendOp"
         Pass
         {
             CGPROGRAM
-            #include "../shared.cginc"
+            #include_with_pragmas "../shared.cginc"
 
             sampler2D _TextureA;
             sampler2D _TextureB;

--- a/Assets/Windinator/Core/Runtime/UIExtension/Resources/Windinator.SDF/Operations/CircleDrawerOp.shader
+++ b/Assets/Windinator/Core/Runtime/UIExtension/Resources/Windinator.SDF/Operations/CircleDrawerOp.shader
@@ -46,7 +46,7 @@ Shader "UI/Windinator/DrawCircle"
         Pass
         {
             CGPROGRAM
-            #include "../shared.cginc"
+            #include_with_pragmas "../shared.cginc"
 
             uniform float4 _Points[512];
             int _PointsCount;

--- a/Assets/Windinator/Core/Runtime/UIExtension/Resources/Windinator.SDF/Operations/ClearOp.shader
+++ b/Assets/Windinator/Core/Runtime/UIExtension/Resources/Windinator.SDF/Operations/ClearOp.shader
@@ -46,7 +46,7 @@ Shader "UI/Windinator/ClearOp"
         Pass
         {
             CGPROGRAM
-            #include "../shared.cginc"
+            #include_with_pragmas "../shared.cginc"
             
             float4 frag (v2f IN) : SV_Target
             {

--- a/Assets/Windinator/Core/Runtime/UIExtension/Resources/Windinator.SDF/Operations/LineDrawerOp.shader
+++ b/Assets/Windinator/Core/Runtime/UIExtension/Resources/Windinator.SDF/Operations/LineDrawerOp.shader
@@ -20,7 +20,7 @@ Shader "UI/Windinator/DrawLine"
     {
         CGINCLUDE
 
-        #include "../shared.cginc"
+        #include_with_pragmas "../shared.cginc"
 
         uniform float4 _Points[512];
         int _PointsCount;

--- a/Assets/Windinator/Core/Runtime/UIExtension/Resources/Windinator.SDF/Operations/PolygonDrawerOp.shader
+++ b/Assets/Windinator/Core/Runtime/UIExtension/Resources/Windinator.SDF/Operations/PolygonDrawerOp.shader
@@ -47,7 +47,7 @@ Shader "UI/Windinator/DrawPoly"
         {
             CGPROGRAM
 
-            #include "../shared.cginc"
+            #include_with_pragmas "../shared.cginc"
 
             uniform float2 _Points[2048];
 

--- a/Assets/Windinator/Core/Runtime/UIExtension/Resources/Windinator.SDF/Operations/RectDrawerOp.shader
+++ b/Assets/Windinator/Core/Runtime/UIExtension/Resources/Windinator.SDF/Operations/RectDrawerOp.shader
@@ -47,7 +47,7 @@ Shader "UI/Windinator/DrawRect"
         {
             CGPROGRAM
 
-            #include "../shared.cginc"
+            #include_with_pragmas "../shared.cginc"
 
             uniform float4 _Points[512];
             uniform float4 _PointsExtra[512];

--- a/Assets/Windinator/Core/Runtime/UIExtension/Resources/Windinator.SDF/PolygonRenderer.shader
+++ b/Assets/Windinator/Core/Runtime/UIExtension/Resources/Windinator.SDF/PolygonRenderer.shader
@@ -46,7 +46,7 @@ Shader "UI/Windinator/PolygonRenderer"
         Pass
         {
             CGPROGRAM
-            #include "shared.cginc"
+            #include_with_pragmas "shared.cginc"
             
             uniform float2 _Points[2048];
 

--- a/Assets/Windinator/Core/Runtime/UIExtension/Resources/Windinator.SDF/RectangleRenderer.shader
+++ b/Assets/Windinator/Core/Runtime/UIExtension/Resources/Windinator.SDF/RectangleRenderer.shader
@@ -46,7 +46,7 @@ Shader "UI/Windinator/RectangleRenderer"
         Pass
         {
             CGPROGRAM
-            #include "shared.cginc"
+            #include_with_pragmas "shared.cginc"
 
             float sdRoundedBox(float2 p, float2 b, float4 r )
             {


### PR DESCRIPTION
Fix for #4 

Unity 2023 onwards (including Unity 6) requires `vertex `and `fragment` `#pragma` lines to be in the top level `.shader` file unless the nested include files use the Unity specific `#include_with_pragmas` directive in place of the standard `#include` directive: https://docs.unity3d.com/2020.3/Documentation/ScriptReference/EditorSettings-cachingShaderPreprocessor.html