### PR TITLE
#7 RenderTexture needs Destroy() calling after Release() 

### DIFF
--- a/Assets/Windinator/Core/Runtime/UIExtension/CanvasGraphic.cs
+++ b/Assets/Windinator/Core/Runtime/UIExtension/CanvasGraphic.cs
@@ -157,15 +157,12 @@ namespace Riten.Windinator.Shapes
 
             if (m_mainLayer == null || !m_mainLayer.IsCreated || m_finalBuffer == null || m_finalBuffer.width != w || m_finalBuffer.height != h)
             {
-                if (m_finalBuffer != null && m_finalBuffer.IsCreated())
-                    m_finalBuffer.Release();
+                WindinatorUtils.Destroy(ref m_finalBuffer);
                 
                 m_mainLayer?.Dispose();
 
-                m_finalBuffer = new RenderTexture(w, h, 0, RenderTextureFormat.RG32);
+                WindinatorUtils.Create(ref m_finalBuffer, w, h, RenderTextureFormat.RG32);
                 m_finalBuffer.name = "SDF";
-                m_finalBuffer.useMipMap = false;
-                m_finalBuffer.Create();
 
                 m_mainLayer = new LayerGraphic(w, h);
 

--- a/Assets/Windinator/Core/Runtime/UIExtension/LayerGraphic.cs
+++ b/Assets/Windinator/Core/Runtime/UIExtension/LayerGraphic.cs
@@ -5,8 +5,8 @@ namespace Riten.Windinator.Shapes
 {
     public class LayerGraphic : IDisposable
     {
-        readonly RenderTexture m_buffer, m_backBuffer;
-        readonly RenderTexture m_colorBuffer, m_backColorBuffer;
+        RenderTexture m_buffer, m_backBuffer;
+        RenderTexture m_colorBuffer, m_backColorBuffer;
 
         bool m_useBackbuffer;
 
@@ -21,27 +21,14 @@ namespace Riten.Windinator.Shapes
             HasColorSupport = createColorBuffer;
             m_useBackbuffer = false;
 
-            m_buffer = new RenderTexture(width, height, 0, RenderTextureFormat.RG32);
-            m_backBuffer = new RenderTexture(width, height, 0, RenderTextureFormat.RG32);
-
-            m_buffer.useMipMap = false;
-            m_backBuffer.useMipMap = false;
-
-            m_buffer.Create();
-            m_backBuffer.Create();
+            WindinatorUtils.Create(ref m_buffer, width, height, RenderTextureFormat.RG32);
+            WindinatorUtils.Create(ref m_backBuffer, width, height, RenderTextureFormat.RG32);
 
             if (createColorBuffer)
             {
-                m_colorBuffer = new RenderTexture(width, height, 0, RenderTextureFormat.ARGB32);
-                m_backColorBuffer = new RenderTexture(width, height, 0, RenderTextureFormat.ARGB32);
-
-                m_colorBuffer.useMipMap = false;
-                m_backColorBuffer.useMipMap = false;
-
-                m_colorBuffer.Create();
-                m_backColorBuffer.Create();
+                WindinatorUtils.Create(ref m_colorBuffer, width, height, RenderTextureFormat.ARGB32);
+                WindinatorUtils.Create(ref m_backColorBuffer, width, height, RenderTextureFormat.ARGB32);
             }
-
 
             IsCreated = true;
         }
@@ -68,14 +55,14 @@ namespace Riten.Windinator.Shapes
         {
             if (IsCreated)
             {
-                m_buffer.Release();
-                m_backBuffer.Release();
+                WindinatorUtils.Destroy(ref m_buffer);
+                WindinatorUtils.Destroy(ref m_backBuffer);
                 IsCreated = false;
 
                 if (HasColorSupport)
                 {
-                    m_colorBuffer.Release();
-                    m_backColorBuffer.Release();
+                    WindinatorUtils.Destroy(ref m_colorBuffer);
+                    WindinatorUtils.Destroy(ref m_backColorBuffer);
                 }
             }
         }

--- a/Assets/Windinator/Core/Runtime/UIExtension/WindinatorUtils.cs
+++ b/Assets/Windinator/Core/Runtime/UIExtension/WindinatorUtils.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections;
 using System.Collections.Generic;
 using UnityEngine;
@@ -17,5 +18,24 @@ public static class WindinatorUtils
         RectTransformUtility.ScreenPointToLocalPointInRectangle(parent, screenPosition, camera, out var tempVector);
 
         return tempVector;
+    }
+
+
+    public static bool Create(ref RenderTexture texture, int width, int height, RenderTextureFormat format) {
+        texture = new RenderTexture(width, height, 0, format) { useMipMap = false };
+        return texture.Create();
+    }
+
+    public static void Destroy(ref RenderTexture texture) {
+        if (texture != null) {
+            texture.Release();
+            if (Application.isPlaying) {
+                RenderTexture.Destroy(texture);
+            }
+            else {
+                RenderTexture.DestroyImmediate(texture);
+            }
+        }
+        texture = null;
     }
 }


### PR DESCRIPTION
Fix for #7 

Spotted after running the `NumberBlending `demo for 50s+, the Unity Editor would eventually fail with "`Resource ID out of range`" when calling to `GetResource`/`SetResource`.